### PR TITLE
Support 2026 schedule occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,45 @@ Inspired by the
 [Teddy Rocks Festival clash finder](https://teddyrocks.co.uk/lineup/clashfinder)
 and [bus timetables](https://www.morebus.co.uk/services/WDBC/m2).
 
+
+## Schedule JSON payload
+
+The planner loads the public EMF schedule JSON, currently from `https://www.emfcamp.org/schedule/2026.json`. The 2026 payload is an array of event objects, and each event can contain one or more scheduled `occurrences`. Older payloads may put `start_date`, `end_date`, and `venue` directly on the event instead; the app supports both shapes.
+
+Top-level event fields currently handled or worth preserving are:
+
+| Field | Description |
+| --- | --- |
+| `id` | Numeric event identifier. This is also used for favourites, so multiple occurrences of the same event share favourite state. |
+| `type` | Content type, such as `performance` or `workshop`. Useful for future filtering or badges. |
+| `names` | Speaker, performer, organiser, or host names as display text. |
+| `pronouns` | Optional pronoun text for the listed people. |
+| `title` | Event title shown on the timeline. |
+| `description` | Full event description, often with paragraphs. |
+| `short_description` | Short summary suitable for compact displays. |
+| `video_privacy` | Recording/streaming privacy setting for the event, such as `public`. |
+| `is_fave` | Favourite state from the upstream schedule payload, when provided. The planner currently uses its own imported/local favourites instead. |
+| `official_content` | Whether this is official EMF content. |
+| `slug` | URL-friendly event slug. |
+| `link` | Canonical event page URL. |
+| `occurrences` | Array of scheduled instances for the event. Each occurrence is rendered separately on the timeline. |
+
+Occurrence fields currently seen in the 2026 payload are:
+
+| Field | Description |
+| --- | --- |
+| `occurrence_num` | Sequence number for this occurrence of the parent event. |
+| `start_date` | Start date and time, for example `2026-07-17 19:00:00`. |
+| `end_date` | End date and time, for example `2026-07-17 20:00:00`. |
+| `venue` | Venue name used to group events into timeline rows. |
+| `latlon` | Optional `[latitude, longitude]` pair for the venue/location. |
+| `map_link` | Optional link to the EMF map at the event location. |
+| `uses_lottery` | Whether attendance uses a lottery/ballot process. |
+| `video_privacy` | Occurrence-specific recording/streaming privacy setting. |
+| `recording_lost` | Whether a recording for this occurrence is unavailable/lost. |
+| `start_time` | Display-only start time, such as `19:00`. |
+| `end_time` | Display-only end time, such as `20:00`. |
+
 ## Development
 
 The code is currently vanilla HTML and JavaScript.

--- a/src/js/Event.js
+++ b/src/js/Event.js
@@ -1,11 +1,12 @@
 class Event {
-  constructor(id, title, start_date, end_date, venue, link) {
+  constructor(id, title, start_date, end_date, venue, link, occurrence = null) {
     this.id = id;
     this.title = title;
     this.start_date = new Date(start_date);
     this.end_date = new Date(end_date);
     this.venue = venue;
     this.link = link;
+    this.occurrence = occurrence;
     this._isFavourite = false;
     this.onFavouriteChange = null; // Callback for changes
   }
@@ -27,13 +28,16 @@ class Event {
   }
 
   static createFromJson(json) {
+    const occurrence = json.occurrence || json;
+
     return new Event(
       json.id,
       json.title,
-      json.start_date,
-      json.end_date,
-      json.venue,
-      json.link
+      occurrence.start_date,
+      occurrence.end_date,
+      occurrence.venue,
+      json.link,
+      json.occurrence || null
     );
   }
 }

--- a/src/js/Schedule.js
+++ b/src/js/Schedule.js
@@ -57,10 +57,25 @@ class Schedule {
         const schedule = new Schedule();
 
         events.forEach(event => {
-            schedule.addEvent(Event.createFromJson(event));
+            Schedule.normaliseEventOccurrences(event).forEach(occurrenceEvent => {
+                schedule.addEvent(Event.createFromJson(occurrenceEvent));
+            });
         });
 
         return schedule;
+    }
+
+    static normaliseEventOccurrences(event) {
+        if (!Array.isArray(event.occurrences)) {
+            return [event];
+        }
+
+        return event.occurrences.map(occurrence => ({
+            ...event,
+            ...occurrence,
+            occurrence,
+            occurrences: undefined,
+        }));
     }
 }
 


### PR DESCRIPTION
### Motivation
- The 2026 schedule JSON uses a top-level `occurrences` array per event instead of flat event fields, so the planner must expand occurrences into individual timeline events while remaining compatible with older payloads.

### Description
- Update `Schedule.createFromJson` to expand events with `occurrences` using a new helper `Schedule.normaliseEventOccurrences` that returns one entry per occurrence or the original event if none exist.
- Add `Schedule.normaliseEventOccurrences` which maps each occurrence into a merged object containing occurrence fields and preserves a reference to the original occurrence as `occurrence`.
- Change `Event` to accept an optional `occurrence` argument and to read `start_date`, `end_date`, and `venue` from the occurrence when present, while storing `occurrence` on the `Event` instance for future use.
- Preserve backwards compatibility for the older flat event shape and keep favourites logic based on the shared event `id`.

### Testing
- Built the app with `npm run build` and `webpack` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f43ffa8c0832baa7d75cbfcfef8b0)