### PR TITLE
Add hidden event filters for favourites, type, official, and venue

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,39 @@
             <input type="file" id="favouritesJsonFileInput" accept=".json" />
           </div>
           <div>
+            <h2>Event filters</h2>
+            <details>
+              <summary>Show filters</summary>
+              <div class="event-filters">
+                <label>
+                  <input type="checkbox" id="filterFavouritesOnly" />
+                  Favourites only
+                </label>
+                <label>
+                  Type
+                  <select id="filterType">
+                    <option value="">All types</option>
+                  </select>
+                </label>
+                <label>
+                  Official
+                  <select id="filterOfficial">
+                    <option value="">All events</option>
+                    <option value="true">Official only</option>
+                    <option value="false">Unofficial only</option>
+                  </select>
+                </label>
+                <label>
+                  Venue
+                  <select id="filterVenue">
+                    <option value="">All venues</option>
+                  </select>
+                </label>
+                <button type="button" id="resetFilters">Reset filters</button>
+              </div>
+            </details>
+          </div>
+          <div>
             <h2>Add to home screen</h2>
             <p>Tap your browser's menu or share button, then <strong>Install app</strong> or <strong>Add to Home screen</strong>.</p>
           </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -65,6 +65,19 @@ header .header-right {
 
 header .controls {
     border: 1px solid var(--cream);
+    padding: 0 1em 1em;
+}
+
+.event-filters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.event-filters label {
+    display: flex;
+    justify-content: space-between;
+    gap: 1em;
 }
 /************** TIMELINE **************/
 

--- a/src/js/Event.js
+++ b/src/js/Event.js
@@ -1,5 +1,5 @@
 class Event {
-  constructor(id, title, start_date, end_date, venue, link, occurrence = null) {
+  constructor(id, title, start_date, end_date, venue, link, occurrence = null, type = null, isOfficial = false) {
     this.id = id;
     this.title = title;
     this.start_date = new Date(start_date);
@@ -7,6 +7,8 @@ class Event {
     this.venue = venue;
     this.link = link;
     this.occurrence = occurrence;
+    this.type = type;
+    this.isOfficial = isOfficial;
     this._isFavourite = false;
     this.onFavouriteChange = null; // Callback for changes
   }
@@ -37,7 +39,9 @@ class Event {
       occurrence.end_date,
       occurrence.venue,
       json.link,
-      json.occurrence || null
+      json.occurrence || null,
+      json.type || null,
+      Boolean(json.is_official)
     );
   }
 }

--- a/src/js/FavouritesDatabase.js
+++ b/src/js/FavouritesDatabase.js
@@ -26,7 +26,7 @@ class FavouritesDatabase {
     this.schedule.setFavourites(this.favourites);
   }
 
-  attachToFileInput(fileInput) {
+  attachToFileInput(fileInput, onSave = null) {
     fileInput.addEventListener('change', async (event) => {
       const file = event.target.files[0];
       const text = await file.text();
@@ -34,6 +34,9 @@ class FavouritesDatabase {
       const ids = json.map((event) => event.id);
       alert(`Imported ${ids.length} favourites!`);
       this.save(ids);
+      if (onSave) {
+        onSave(ids);
+      }
     });
   }
 }

--- a/src/js/Schedule.js
+++ b/src/js/Schedule.js
@@ -47,6 +47,14 @@ class Schedule {
         return Object.values(this.venues);
     }
 
+    getEventTypes() {
+        return [...new Set(this.events.map(event => event.type).filter(Boolean))].sort();
+    }
+
+    getVenueNames() {
+        return Object.keys(this.venues).sort();
+    }
+
     setFavourites(listOfIds) {
         this.events.forEach(event => {
             event.isFavourite = listOfIds.includes(event.id);

--- a/src/js/Timeline.js
+++ b/src/js/Timeline.js
@@ -8,6 +8,12 @@ class Timeline {
   constructor(domElement, schedule) {
     this.domElement = domElement;
     this.schedule = schedule;
+    this.filters = {
+      favouritesOnly: false,
+      type: '',
+      official: '',
+      venue: '',
+    };
     this.render();
   }
 
@@ -16,6 +22,34 @@ class Timeline {
     const endTime = this.schedule.getEndDate();
     const timeRange = endTime - startTime;
     return ((date - startTime) / timeRange) * 100;
+  }
+
+  setFilters(filters) {
+    this.filters = {
+      ...this.filters,
+      ...filters,
+    };
+    this.render();
+  }
+
+  eventMatchesFilters(event) {
+    if (this.filters.favouritesOnly && !event.isFavourite) {
+      return false;
+    }
+
+    if (this.filters.type && event.type !== this.filters.type) {
+      return false;
+    }
+
+    if (this.filters.official !== '' && String(event.isOfficial) !== this.filters.official) {
+      return false;
+    }
+
+    if (this.filters.venue && event.venue !== this.filters.venue) {
+      return false;
+    }
+
+    return true;
   }
 
   render() {
@@ -37,6 +71,11 @@ class Timeline {
 
     // Create timeline rows for each venue
     for (const venue of this.schedule.getVenues()) {
+      const filteredEvents = venue.events.filter(event => this.eventMatchesFilters(event));
+
+      if (filteredEvents.length === 0) {
+        continue;
+      }
 
       // <div class="timeline-row"><div class="venue-details"></div><div class="events"></div></div>
 
@@ -49,7 +88,7 @@ class Timeline {
       row.appendChild(container);
 
       // Place events on the timeline
-      venue.events.forEach(event => {
+      filteredEvents.forEach(event => {
         const eventBlock = new EventBlock(event);
 
         eventBlock.positionBetween(startTime, endTime);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -11,6 +11,47 @@ const fetchData = async (url) => {
   }
 };
 
+const addOptions = (selectElement, values) => {
+  values.forEach(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.innerText = value;
+    selectElement.appendChild(option);
+  });
+};
+
+const attachEventFilters = (timeline, schedule) => {
+  const favouritesOnlyInput = document.getElementById('filterFavouritesOnly');
+  const typeInput = document.getElementById('filterType');
+  const officialInput = document.getElementById('filterOfficial');
+  const venueInput = document.getElementById('filterVenue');
+  const resetButton = document.getElementById('resetFilters');
+
+  addOptions(typeInput, schedule.getEventTypes());
+  addOptions(venueInput, schedule.getVenueNames());
+
+  const applyFilters = () => {
+    timeline.setFilters({
+      favouritesOnly: favouritesOnlyInput.checked,
+      type: typeInput.value,
+      official: officialInput.value,
+      venue: venueInput.value,
+    });
+  };
+
+  [favouritesOnlyInput, typeInput, officialInput, venueInput].forEach(input => {
+    input.addEventListener('change', applyFilters);
+  });
+
+  resetButton.addEventListener('click', () => {
+    favouritesOnlyInput.checked = false;
+    typeInput.value = '';
+    officialInput.value = '';
+    venueInput.value = '';
+    applyFilters();
+  });
+};
+
 document.addEventListener('DOMContentLoaded', async () => {
   const data = await fetchData('https://www.emfcamp.org/schedule/2026.json');
 
@@ -19,13 +60,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const schedule = Schedule.createFromJson(data);
-  const timelineElement = document.getElementById('timeline');
-  const timeline = new Timeline(timelineElement, schedule);
 
   const favouritesDatabase = new FavouritesDatabase(window.localStorage, 'favourites', schedule);
   
   const favouritesFileInput = document.getElementById('favouritesJsonFileInput');
-  favouritesDatabase.attachToFileInput(favouritesFileInput);
+  favouritesDatabase.attachToFileInput(favouritesFileInput, () => timeline.render());
+
+  const timelineElement = document.getElementById('timeline');
+  const timeline = new Timeline(timelineElement, schedule);
+  attachEventFilters(timeline, schedule);
 
   // go to 1 hour ago
   timeline.goToTime(Date.now() - 60 * 60 * 1000);


### PR DESCRIPTION
### Motivation
- Provide a way to filter displayed events by favourites, event `type`, official status (`is_official`), and venue while keeping the UI uncluttered by hiding the controls by default.
- Ensure filters can be populated from schedule metadata and that importing favourites updates the filtered view.

### Description
- Add a collapsed `Event filters` panel in `index.html` containing controls for `Favourites only`, `Type`, `Official`, and `Venue`, plus a `Reset filters` button, and keep it hidden by default inside the existing controls area.
- Preserve `type` and `is_official` on `Event` objects (update `src/js/Event.js`) and add `getEventTypes()` and `getVenueNames()` helpers to `src/js/Schedule.js` to populate filter option lists.
- Implement timeline filtering in `src/js/Timeline.js` with `setFilters()` and `eventMatchesFilters()` so non-matching events (and empty venue rows) are omitted from the view.
- Wire up filter UI in `src/js/app.js`, populate selects from the schedule, and refresh the timeline after favourites imports by adding an optional callback to `FavouritesDatabase.attachToFileInput()` in `src/js/FavouritesDatabase.js`.
- Add small CSS rules in `src/css/style.css` for the hidden filter controls.

### Testing
- Ran `npm run build` and the project compiled successfully with webpack (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a517065f2e8832ba0b57e0397dcae69)