### PR TITLE
Add event details split panel and selection flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,22 @@
       </wa-card>
     </section>
 
-    <main class="timeline-wrapper" aria-label="Timetable">
-      <div id="timeline" class="timeline-container">Loading...</div>
-    </main>
+    <wa-split-panel id="eventSplitPanel" class="event-split-panel no-event-selected" orientation="vertical" position="100">
+      <main slot="start" class="timeline-wrapper" aria-label="Timetable">
+        <div id="timeline" class="timeline-container">Loading...</div>
+      </main>
+
+      <aside slot="end" id="eventDetailsPanel" class="event-details-panel" aria-label="Event details" hidden>
+        <wa-scroller class="event-details-scroller">
+          <div class="event-details-content">
+            <wa-button id="eventDetailsClose" class="event-details-close" appearance="plain" variant="neutral" size="small" aria-label="Close event details">✕</wa-button>
+            <h2 id="eventDetailsTitle">Event details</h2>
+            <dl id="eventDetailsList" class="event-details-list"></dl>
+            <p><a id="eventDetailsLink" href="#" target="_blank" rel="noopener noreferrer">Open event page</a></p>
+          </div>
+        </wa-scroller>
+      </aside>
+    </wa-split-panel>
   </div>
 </body>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -191,6 +191,9 @@ h1 strong {
     position: absolute;
     font-size: 14px;
     text-decoration: none;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
 }
 
 .timeline-events-wrapper .event-block.fav {
@@ -253,4 +256,66 @@ h1 strong {
 
 .day {
     background: rgba(131, 3, 131, 0.5);
+}
+/************** EVENT DETAILS **************/
+
+.event-split-panel {
+    flex: 1;
+    min-height: 0;
+    --divider-color: rgba(207, 204, 192, 0.35);
+    --divider-width: 0.35rem;
+}
+
+.event-split-panel.no-event-selected::part(divider) {
+    display: none;
+}
+
+.event-details-panel[hidden] {
+    display: none;
+}
+
+.event-details-panel {
+    position: relative;
+    min-height: 0;
+    background: rgba(23, 38, 14, 0.96);
+    border-top: 1px solid rgba(207, 204, 192, 0.28);
+}
+
+.event-details-scroller {
+    height: 100%;
+}
+
+.event-details-content {
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 1rem clamp(0.75rem, 2vw, 1.5rem);
+    color: #fff;
+}
+
+.event-details-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+}
+
+.event-details-content h2 {
+    margin: 0 2.5rem 1rem 0;
+    color: var(--light-green);
+    font-size: clamp(1.15rem, 2.5vw, 1.5rem);
+}
+
+.event-details-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.45rem 1rem;
+    margin: 0 0 1rem;
+}
+
+.event-details-list dt {
+    color: var(--cream);
+    font-weight: 700;
+}
+
+.event-details-list dd {
+    margin: 0;
 }

--- a/src/js/EventBlock.js
+++ b/src/js/EventBlock.js
@@ -1,13 +1,14 @@
 import TimelineBlock from "./TimelineBlock.js";
 
 class EventBlock extends TimelineBlock {
-    constructor(event) {
+    constructor(event, onSelect = null) {
         super();
         this.event = event;
         this.startDate = event.start_date;
         this.endDate = event.end_date;
         this.title = event.title;
         this.link = event.link;
+        this.onSelect = onSelect;
         this.domElement = this.render();
 
         this.event.onFavouriteChange = (isFav) => this.updateFavouriteStatus(isFav);
@@ -16,12 +17,12 @@ class EventBlock extends TimelineBlock {
     }
 
     render() {
-        const eventElement = document.createElement('a');
-        eventElement.href = this.link;
-        eventElement.target = '_blank';
+        const eventElement = document.createElement('button');
+        eventElement.type = 'button';
         eventElement.className = 'event-block';
         eventElement.classList.add('timeline-block');
         eventElement.innerText = this.title;
+        eventElement.addEventListener('click', () => this.onSelect?.(this.event));
 
         return eventElement;
     }

--- a/src/js/Timeline.js
+++ b/src/js/Timeline.js
@@ -5,9 +5,10 @@ import HoursTicksRow from './HoursTicksRow.js';
 
 
 class Timeline {
-  constructor(domElement, schedule) {
+  constructor(domElement, schedule, onEventSelect = null) {
     this.domElement = domElement;
     this.schedule = schedule;
+    this.onEventSelect = onEventSelect;
     this.filters = {
       favouritesOnly: false,
       type: '',
@@ -89,7 +90,7 @@ class Timeline {
 
       // Place events on the timeline
       filteredEvents.forEach(event => {
-        const eventBlock = new EventBlock(event);
+        const eventBlock = new EventBlock(event, this.onEventSelect);
 
         eventBlock.positionBetween(startTime, endTime);
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -31,6 +31,56 @@ const attachSettingsToggle = () => {
   });
 };
 
+
+const formatEventDate = (date) => new Intl.DateTimeFormat(undefined, {
+  weekday: 'short',
+  day: 'numeric',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+}).format(date);
+
+const appendDetail = (detailsList, label, value) => {
+  if (!value) {
+    return;
+  }
+
+  const term = document.createElement('dt');
+  term.innerText = label;
+  const description = document.createElement('dd');
+  description.innerText = value;
+  detailsList.append(term, description);
+};
+
+const attachEventDetailsPanel = () => {
+  const splitPanel = document.getElementById('eventSplitPanel');
+  const closeButton = document.getElementById('eventDetailsClose');
+  const panel = document.getElementById('eventDetailsPanel');
+  const title = document.getElementById('eventDetailsTitle');
+  const detailsList = document.getElementById('eventDetailsList');
+  const link = document.getElementById('eventDetailsLink');
+
+  closeButton.addEventListener('click', () => {
+    panel.hidden = true;
+    splitPanel.classList.add('no-event-selected');
+    splitPanel.position = 100;
+  });
+
+  return (event) => {
+    title.innerText = event.title;
+    detailsList.innerHTML = '';
+    appendDetail(detailsList, 'Starts', formatEventDate(event.start_date));
+    appendDetail(detailsList, 'Ends', formatEventDate(event.end_date));
+    appendDetail(detailsList, 'Venue', event.venue);
+    appendDetail(detailsList, 'Type', event.type);
+    appendDetail(detailsList, 'Official', event.isOfficial ? 'Yes' : 'No');
+    link.href = event.link;
+    panel.hidden = false;
+    splitPanel.classList.remove('no-event-selected');
+    splitPanel.position = 60;
+  };
+};
+
 const attachEventFilters = (timeline, schedule) => {
   const favouritesOnlyInput = document.getElementById('filterFavouritesOnly');
   const typeInput = document.getElementById('filterType');
@@ -79,8 +129,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const favouritesFileInput = document.getElementById('favouritesJsonFileInput');
   favouritesDatabase.attachToFileInput(favouritesFileInput, () => timeline.render());
 
+  const showEventDetails = attachEventDetailsPanel();
   const timelineElement = document.getElementById('timeline');
-  const timeline = new Timeline(timelineElement, schedule);
+  const timeline = new Timeline(timelineElement, schedule, showEventDetails);
   attachEventFilters(timeline, schedule);
 
   // go to 1 hour ago


### PR DESCRIPTION
### Motivation
- Provide a way to view basic event details in a lower panel that is hidden by default and shown only when tapping an event, with a close control and an external link to the event page.

### Description
- Wrap the timeline in a vertical `wa-split-panel` and add an aside details pane with a `wa-scroller`, a close button, a details `dl` and an external link; the split is hidden by default via a `no-event-selected` class and `position=100` (`index.html`).
- Change `EventBlock` to render a `button` and call a selection callback instead of navigating directly, and update `Timeline` to accept and forward an `onEventSelect` callback (`src/js/EventBlock.js`, `src/js/Timeline.js`).
- Implement `attachEventDetailsPanel` in `src/js/app.js` with `formatEventDate` and `appendDetail` to populate the details pane, open it on selection and hide it when the close button is tapped, and wire the callback into timeline initialization.
- Add styles for the split panel and details pane and adjust `.event-block` visuals to act like a button while preserving appearance (`src/css/style.css`).

### Testing
- Ran `npm run build` and Webpack compiled successfully, producing the app and style bundles (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51fe7840d8832bb216f88c876e3aaf)