### PR TITLE
Switch settings to wa-drawer, tighten timetable event spacing, and enhance event details UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,8 @@
       </nav>
     </header>
 
-    <section id="settingsPanel" class="settings-panel" hidden aria-label="Planner settings">
+    <wa-drawer id="settingsPanel" class="settings-panel" label="Settings" placement="end">
       <wa-card class="settings-card">
-        <h2 slot="header">Settings</h2>
         <wa-tab-group>
           <wa-tab slot="nav" panel="favourites">Favourites</wa-tab>
           <wa-tab slot="nav" panel="filters">Filters</wa-tab>
@@ -86,9 +85,10 @@
           </wa-tab-panel>
         </wa-tab-group>
       </wa-card>
-    </section>
+    </wa-drawer>
 
     <wa-split-panel id="eventSplitPanel" class="event-split-panel no-event-selected" orientation="vertical" position="100">
+      <wa-icon slot="divider" name="grip-vertical" variant="solid"></wa-icon>
       <main slot="start" class="timeline-wrapper" aria-label="Timetable">
         <div id="timeline" class="timeline-container">Loading...</div>
       </main>
@@ -97,9 +97,10 @@
         <wa-scroller class="event-details-scroller">
           <div class="event-details-content">
             <wa-button id="eventDetailsClose" class="event-details-close" appearance="plain" variant="neutral" size="small" aria-label="Close event details">✕</wa-button>
-            <h2 id="eventDetailsTitle">Event details</h2>
+            <h2><a id="eventDetailsTitle" class="event-details-title-link" href="#" target="_blank" rel="noopener noreferrer">Event details <wa-icon name="arrow-up-right-from-square" variant="solid"></wa-icon></a></h2>
+            <p id="eventDetailsTime" class="event-details-time"></p>
             <dl id="eventDetailsList" class="event-details-list"></dl>
-            <p><a id="eventDetailsLink" href="#" target="_blank" rel="noopener noreferrer">Open event page</a></p>
+            <div id="eventDetailsText" class="event-details-text"></div>
           </div>
         </wa-scroller>
       </aside>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -72,15 +72,9 @@ h1 strong {
     justify-content: flex-end;
 }
 
-.settings-panel {
+.settings-panel::part(body) {
+    background: rgba(23, 38, 14, 0.96);
     padding: 1rem clamp(0.75rem, 2vw, 1.5rem);
-    background: rgba(23, 38, 14, 0.88);
-    border-bottom: 1px solid rgba(207, 204, 192, 0.22);
-    z-index: 2;
-}
-
-.settings-panel[hidden] {
-    display: none;
 }
 
 .settings-card {
@@ -185,7 +179,8 @@ h1 strong {
     white-space: normal;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: 5px;
+    /* Intentionally compact so two lines of timetable text remain visible. */
+    padding: 1px 4px;
     color: #fff;
     display: inline-block;
     position: absolute;
@@ -263,7 +258,11 @@ h1 strong {
     flex: 1;
     min-height: 0;
     --divider-color: rgba(207, 204, 192, 0.35);
-    --divider-width: 0.35rem;
+    --divider-width: 20px;
+}
+
+.event-split-panel wa-icon[slot="divider"] {
+    color: var(--cream);
 }
 
 .event-split-panel.no-event-selected::part(divider) {
@@ -299,9 +298,23 @@ h1 strong {
 }
 
 .event-details-content h2 {
-    margin: 0 2.5rem 1rem 0;
-    color: var(--light-green);
+    margin: 0 2.5rem 0.35rem 0;
     font-size: clamp(1.15rem, 2.5vw, 1.5rem);
+}
+
+.event-details-title-link {
+    color: var(--light-green);
+    text-decoration: underline;
+}
+
+.event-details-title-link wa-icon {
+    font-size: 0.75em;
+}
+
+.event-details-time {
+    margin: 0 0 1rem;
+    color: var(--cream);
+    font-weight: 700;
 }
 
 .event-details-list {
@@ -309,6 +322,16 @@ h1 strong {
     grid-template-columns: max-content 1fr;
     gap: 0.45rem 1rem;
     margin: 0 0 1rem;
+}
+
+.event-details-text p {
+    margin: 0 0 1rem;
+    white-space: pre-line;
+}
+
+.event-details-short-description {
+    color: var(--cream);
+    font-weight: 700;
 }
 
 .event-details-list dt {

--- a/src/js/Event.js
+++ b/src/js/Event.js
@@ -1,5 +1,5 @@
 class Event {
-  constructor(id, title, start_date, end_date, venue, link, occurrence = null, type = null, isOfficial = false) {
+  constructor(id, title, start_date, end_date, venue, link, occurrence = null, type = null, isOfficial = false, shortDescription = null, description = null, names = null, mapLink = null) {
     this.id = id;
     this.title = title;
     this.start_date = new Date(start_date);
@@ -9,6 +9,10 @@ class Event {
     this.occurrence = occurrence;
     this.type = type;
     this.isOfficial = isOfficial;
+    this.shortDescription = shortDescription;
+    this.description = description;
+    this.names = names;
+    this.mapLink = mapLink;
     this._isFavourite = false;
     this.onFavouriteChange = null; // Callback for changes
   }
@@ -41,7 +45,11 @@ class Event {
       json.link,
       json.occurrence || null,
       json.type || null,
-      Boolean(json.is_official)
+      Boolean(json.is_official || json.official_content),
+      json.short_description || null,
+      json.description || null,
+      json.names || null,
+      occurrence.map_link || json.map_link || null
     );
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -25,17 +25,17 @@ const attachSettingsToggle = () => {
   const settingsPanel = document.getElementById('settingsPanel');
 
   settingsToggle.addEventListener('click', () => {
-    const isHidden = settingsPanel.hidden;
-    settingsPanel.hidden = !isHidden;
-    settingsToggle.setAttribute('aria-expanded', String(isHidden));
+    settingsPanel.open = !settingsPanel.open;
+    settingsToggle.setAttribute('aria-expanded', String(settingsPanel.open));
+  });
+
+  settingsPanel.addEventListener('wa-after-hide', () => {
+    settingsToggle.setAttribute('aria-expanded', 'false');
   });
 };
 
-
-const formatEventDate = (date) => new Intl.DateTimeFormat(undefined, {
+const formatEventDayTime = (date) => new Intl.DateTimeFormat(undefined, {
   weekday: 'short',
-  day: 'numeric',
-  month: 'short',
   hour: '2-digit',
   minute: '2-digit',
 }).format(date);
@@ -48,8 +48,38 @@ const appendDetail = (detailsList, label, value) => {
   const term = document.createElement('dt');
   term.innerText = label;
   const description = document.createElement('dd');
-  description.innerText = value;
+
+  if (value instanceof Node) {
+    description.appendChild(value);
+  } else {
+    description.innerText = value;
+  }
+
   detailsList.append(term, description);
+};
+
+const appendTextSection = (container, className, value) => {
+  if (!value) {
+    return;
+  }
+
+  const section = document.createElement('p');
+  section.className = className;
+  section.innerText = value;
+  container.appendChild(section);
+};
+
+const getVenueDetail = (event) => {
+  if (!event.mapLink) {
+    return event.venue;
+  }
+
+  const link = document.createElement('a');
+  link.href = event.mapLink;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.innerText = event.venue;
+  return link;
 };
 
 const attachEventDetailsPanel = () => {
@@ -58,7 +88,8 @@ const attachEventDetailsPanel = () => {
   const panel = document.getElementById('eventDetailsPanel');
   const title = document.getElementById('eventDetailsTitle');
   const detailsList = document.getElementById('eventDetailsList');
-  const link = document.getElementById('eventDetailsLink');
+  const time = document.getElementById('eventDetailsTime');
+  const text = document.getElementById('eventDetailsText');
 
   closeButton.addEventListener('click', () => {
     panel.hidden = true;
@@ -67,14 +98,21 @@ const attachEventDetailsPanel = () => {
   });
 
   return (event) => {
-    title.innerText = event.title;
+    title.innerHTML = '';
+    const titleIcon = document.createElement('wa-icon');
+    titleIcon.setAttribute('name', 'arrow-up-right-from-square');
+    titleIcon.setAttribute('variant', 'solid');
+    title.append(document.createTextNode(`${event.title} `), titleIcon);
+    title.href = event.link;
+    time.innerText = `${formatEventDayTime(event.start_date)}–${formatEventDayTime(event.end_date)}`;
     detailsList.innerHTML = '';
-    appendDetail(detailsList, 'Starts', formatEventDate(event.start_date));
-    appendDetail(detailsList, 'Ends', formatEventDate(event.end_date));
-    appendDetail(detailsList, 'Venue', event.venue);
+    text.innerHTML = '';
+    appendDetail(detailsList, 'Venue', getVenueDetail(event));
+    appendDetail(detailsList, 'Running', event.names);
     appendDetail(detailsList, 'Type', event.type);
     appendDetail(detailsList, 'Official', event.isOfficial ? 'Yes' : 'No');
-    link.href = event.link;
+    appendTextSection(text, 'event-details-short-description', event.shortDescription);
+    appendTextSection(text, 'event-details-description', event.description);
     panel.hidden = false;
     splitPanel.classList.remove('no-event-selected');
     splitPanel.position = 60;


### PR DESCRIPTION
### Motivation
- Make the settings panel behave as a proper drawer using the Web Awesome `wa-drawer` so it feels like an overlay rather than inline content.
- Reduce the vertical padding on 2D timetable event blocks so two lines of text are visible (the previous spacing only showed ~1.5 lines).
- Improve the event details panel UX by showing day/time inline, using the event title as a link with an external icon, and including `short_description`, `description`, `names` (who's running), and a venue map link.
- Make the split-panel divider easier to grab by widening it and adding a grip icon.

### Description
- Replaced the inline settings section with a `wa-drawer` in `index.html` and preserved the existing settings content inside the drawer while removing the old hidden section markup.
- Added a divider grip icon to the `wa-split-panel` and updated the event details markup in `index.html` to include an underlined linked title with external icon, an inline time element, and a rich text container for descriptions.
- Updated `src/js/app.js` to toggle the drawer via the drawer `open` property and keep `aria-expanded` in sync, to render the inline weekday/time (`formatEventDayTime`), to build the linked title icon, to render venue map links, to include `names` (running) and to append `short_description` and `description` into the details panel.
- Extended the `Event` model in `src/js/Event.js` to store `shortDescription`, `description`, `names`, and `mapLink`, and updated `createFromJson` to pull `short_description`, `description`, `names`, `map_link` (including occurrence-level `map_link`) and respect `official_content` alongside `is_official`.
- Tightened event block CSS padding in `src/css/style.css` and added a comment documenting that the compact spacing is intentional so two lines remain visible, widened the split-panel divider to `20px`, added styling for the divider grip icon, and added styles for the linked title, inline time, and description sections.

### Testing
- Ran `npm run build` which completed successfully and produced the updated `app` and `style` assets.
- Ran `git diff --check` which returned no spacing/check errors.
- Served the `dist` output with `python3 -m http.server` and verified the root responded with `HTTP/1.0 200 OK` via `curl -I`.
- Verified that headless browser / screenshot tooling was not available in the environment (Chromium / Playwright check failed), so no visual screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a520cec20bc832bb65961fbace76203)