### PR TITLE
Add vertical scrolling to event details

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
       </main>
 
       <aside slot="end" id="eventDetailsPanel" class="event-details-panel" aria-label="Event details" hidden>
-        <wa-scroller class="event-details-scroller">
+        <wa-scroller class="event-details-scroller" orientation="vertical">
           <div class="event-details-content">
             <wa-button id="eventDetailsClose" class="event-details-close" appearance="plain" variant="neutral" size="small" aria-label="Close event details">✕</wa-button>
             <h2><a id="eventDetailsTitle" class="event-details-title-link" href="#" target="_blank" rel="noopener noreferrer">Event details <wa-icon name="arrow-up-right-from-square" variant="solid"></wa-icon></a></h2>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -281,7 +281,12 @@ h1 strong {
 }
 
 .event-details-scroller {
+    display: block;
     height: 100%;
+    max-height: 100%;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .event-details-content {


### PR DESCRIPTION
### Motivation
- Ensure the event details panel (venue, descriptions, running details, etc.) is scrollable vertically so long content is accessible even when the Web Awesome scroller component is not present or doesn't apply.

### Description
- Set `orientation="vertical"` on the `<wa-scroller>` wrapping the event details in `index.html`.
- Add CSS fallback rules in `src/css/style.css` for `.event-details-scroller` including `display: block`, `max-height: 100%`, `min-height: 0`, `overflow-x: hidden`, and `overflow-y: auto` so the panel scrolls vertically via plain CSS when needed.

### Testing
- Ran `npm run build`, which compiled successfully without errors.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5210a1ef20832ba13517acef96c785)