### PR TITLE
Show venue distance and direction in event details

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -347,3 +347,33 @@ h1 strong {
 .event-details-list dd {
     margin: 0;
 }
+
+.venue-distance {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.5rem;
+    color: var(--cream);
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.venue-distance::before {
+    content: "";
+}
+
+.venue-distance-button {
+    border: 1px solid rgba(207, 204, 192, 0.55);
+    border-radius: 999px;
+    background: rgba(207, 204, 192, 0.12);
+    color: var(--cream);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.9em;
+    padding: 0.12rem 0.5rem;
+}
+
+.venue-distance-button:hover,
+.venue-distance-button:focus-visible {
+    background: var(--light-green);
+    color: var(--dark-green);
+}

--- a/src/js/Event.js
+++ b/src/js/Event.js
@@ -1,5 +1,5 @@
 class Event {
-  constructor(id, title, start_date, end_date, venue, link, occurrence = null, type = null, isOfficial = false, shortDescription = null, description = null, names = null, mapLink = null) {
+  constructor(id, title, start_date, end_date, venue, link, occurrence = null, type = null, isOfficial = false, shortDescription = null, description = null, names = null, mapLink = null, latlon = null) {
     this.id = id;
     this.title = title;
     this.start_date = new Date(start_date);
@@ -13,6 +13,7 @@ class Event {
     this.description = description;
     this.names = names;
     this.mapLink = mapLink;
+    this.latlon = Array.isArray(latlon) && latlon.length >= 2 ? latlon.map(Number) : null;
     this._isFavourite = false;
     this.onFavouriteChange = null; // Callback for changes
   }
@@ -49,7 +50,8 @@ class Event {
       json.short_description || null,
       json.description || null,
       json.names || null,
-      occurrence.map_link || json.map_link || null
+      occurrence.map_link || json.map_link || null,
+      occurrence.latlon || json.latlon || null
     );
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -34,6 +34,102 @@ const attachSettingsToggle = () => {
   });
 };
 
+
+const COMPASS_DIRECTIONS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+const GEOLOCATION_OPTIONS = {
+  enableHighAccuracy: true,
+  maximumAge: 15000,
+  timeout: 10000,
+};
+
+const toRadians = (degrees) => degrees * Math.PI / 180;
+const toDegrees = (radians) => radians * 180 / Math.PI;
+
+const isValidLatlon = (latlon) => Array.isArray(latlon)
+  && latlon.length >= 2
+  && latlon.every(coordinate => Number.isFinite(coordinate));
+
+const calculateDistanceMeters = ([fromLatitude, fromLongitude], [toLatitude, toLongitude]) => {
+  const earthRadiusMeters = 6371000;
+  const latitudeDelta = toRadians(toLatitude - fromLatitude);
+  const longitudeDelta = toRadians(toLongitude - fromLongitude);
+  const fromLatitudeRadians = toRadians(fromLatitude);
+  const toLatitudeRadians = toRadians(toLatitude);
+
+  const haversine = Math.sin(latitudeDelta / 2) ** 2
+    + Math.cos(fromLatitudeRadians) * Math.cos(toLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2;
+
+  return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+};
+
+const calculateCompassDirection = ([fromLatitude, fromLongitude], [toLatitude, toLongitude]) => {
+  const fromLatitudeRadians = toRadians(fromLatitude);
+  const toLatitudeRadians = toRadians(toLatitude);
+  const longitudeDelta = toRadians(toLongitude - fromLongitude);
+  const y = Math.sin(longitudeDelta) * Math.cos(toLatitudeRadians);
+  const x = Math.cos(fromLatitudeRadians) * Math.sin(toLatitudeRadians)
+    - Math.sin(fromLatitudeRadians) * Math.cos(toLatitudeRadians) * Math.cos(longitudeDelta);
+  const bearing = (toDegrees(Math.atan2(y, x)) + 360) % 360;
+
+  return COMPASS_DIRECTIONS[Math.round(bearing / 45) % COMPASS_DIRECTIONS.length];
+};
+
+const formatVenueDistance = (userLatlon, venueLatlon) => {
+  if (!isValidLatlon(userLatlon) || !isValidLatlon(venueLatlon)) {
+    return '';
+  }
+
+  const distance = Math.round(calculateDistanceMeters(userLatlon, venueLatlon));
+  const direction = calculateCompassDirection(userLatlon, venueLatlon);
+  return `${distance}m ${direction}`;
+};
+
+const createLocationTracker = () => {
+  const listeners = new Set();
+  let position = null;
+  let error = null;
+  let watchId = null;
+
+  const notify = () => listeners.forEach(listener => listener({ position, error, isWatching: watchId !== null }));
+
+  const start = () => {
+    if (!('geolocation' in navigator)) {
+      error = 'Device location is not supported by this browser.';
+      notify();
+      return;
+    }
+
+    if (watchId !== null) {
+      notify();
+      return;
+    }
+
+    error = null;
+    watchId = navigator.geolocation.watchPosition(
+      ({ coords }) => {
+        position = [coords.latitude, coords.longitude];
+        error = null;
+        notify();
+      },
+      (geolocationError) => {
+        error = geolocationError.message || 'Unable to get device location.';
+        notify();
+      },
+      GEOLOCATION_OPTIONS,
+    );
+    notify();
+  };
+
+  return {
+    start,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener({ position, error, isWatching: watchId !== null });
+      return () => listeners.delete(listener);
+    },
+  };
+};
+
 const formatEventDayTime = (date) => new Intl.DateTimeFormat(undefined, {
   weekday: 'short',
   hour: '2-digit',
@@ -69,20 +165,53 @@ const appendTextSection = (container, className, value) => {
   container.appendChild(section);
 };
 
-const getVenueDetail = (event) => {
-  if (!event.mapLink) {
-    return event.venue;
+const getVenueDetail = (event, locationTracker) => {
+  const container = document.createElement('span');
+  const venueName = event.mapLink ? document.createElement('a') : document.createElement('span');
+
+  if (event.mapLink) {
+    venueName.href = event.mapLink;
+    venueName.target = '_blank';
+    venueName.rel = 'noopener noreferrer';
   }
 
-  const link = document.createElement('a');
-  link.href = event.mapLink;
-  link.target = '_blank';
-  link.rel = 'noopener noreferrer';
-  link.innerText = event.venue;
-  return link;
+  venueName.innerText = event.venue;
+  container.appendChild(venueName);
+
+  if (!isValidLatlon(event.latlon)) {
+    return container;
+  }
+
+  const distance = document.createElement('span');
+  distance.className = 'venue-distance';
+  container.appendChild(distance);
+
+  const unsubscribe = locationTracker.subscribe(({ position, error, isWatching }) => {
+    const formattedDistance = formatVenueDistance(position, event.latlon);
+
+    if (formattedDistance) {
+      distance.innerText = formattedDistance;
+      distance.title = 'Distance and compass direction from your device to the venue';
+    } else if (isWatching && !error) {
+      distance.innerText = 'locating…';
+      distance.title = 'Waiting for your device location';
+    } else {
+      distance.innerHTML = '';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'venue-distance-button';
+      button.innerText = error ? 'Retry location' : 'Show distance';
+      button.title = error || 'Use your device location to show distance and direction to this venue';
+      button.addEventListener('click', locationTracker.start);
+      distance.appendChild(button);
+    }
+  });
+
+  container.unsubscribe = unsubscribe;
+  return container;
 };
 
-const attachEventDetailsPanel = () => {
+const attachEventDetailsPanel = (locationTracker) => {
   const splitPanel = document.getElementById('eventSplitPanel');
   const closeButton = document.getElementById('eventDetailsClose');
   const panel = document.getElementById('eventDetailsPanel');
@@ -91,13 +220,23 @@ const attachEventDetailsPanel = () => {
   const time = document.getElementById('eventDetailsTime');
   const text = document.getElementById('eventDetailsText');
 
+  let unsubscribeVenueDetail = null;
+
   closeButton.addEventListener('click', () => {
+    if (unsubscribeVenueDetail) {
+      unsubscribeVenueDetail();
+      unsubscribeVenueDetail = null;
+    }
     panel.hidden = true;
     splitPanel.classList.add('no-event-selected');
     splitPanel.position = 100;
   });
 
   return (event) => {
+    if (unsubscribeVenueDetail) {
+      unsubscribeVenueDetail();
+      unsubscribeVenueDetail = null;
+    }
     title.innerHTML = '';
     const titleIcon = document.createElement('wa-icon');
     titleIcon.setAttribute('name', 'arrow-up-right-from-square');
@@ -107,7 +246,9 @@ const attachEventDetailsPanel = () => {
     time.innerText = `${formatEventDayTime(event.start_date)}–${formatEventDayTime(event.end_date)}`;
     detailsList.innerHTML = '';
     text.innerHTML = '';
-    appendDetail(detailsList, 'Venue', getVenueDetail(event));
+    const venueDetail = getVenueDetail(event, locationTracker);
+    unsubscribeVenueDetail = venueDetail.unsubscribe || null;
+    appendDetail(detailsList, 'Venue', venueDetail);
     appendDetail(detailsList, 'Running', event.names);
     appendDetail(detailsList, 'Type', event.type);
     appendDetail(detailsList, 'Official', event.isOfficial ? 'Yes' : 'No');
@@ -167,7 +308,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const favouritesFileInput = document.getElementById('favouritesJsonFileInput');
   favouritesDatabase.attachToFileInput(favouritesFileInput, () => timeline.render());
 
-  const showEventDetails = attachEventDetailsPanel();
+  const locationTracker = createLocationTracker();
+  const showEventDetails = attachEventDetailsPanel(locationTracker);
   const timelineElement = document.getElementById('timeline');
   const timeline = new Timeline(timelineElement, schedule, showEventDetails);
   attachEventFilters(timeline, schedule);


### PR DESCRIPTION
### Motivation
- Display the straight-line distance (in meters) and an 8-point compass direction from the user's device to an event venue in the event details panel. 
- Request and manage device geolocation at a sensible time via a user action, and update the displayed distance as the user moves.
- Provide a clear fallback UI when location permission is unavailable or pending.

### Description
- Preserve occurrence `latlon` on event models by adding a `latlon` parameter to `Event` and passing `occurrence.latlon || json.latlon` through `Event.createFromJson` (`src/js/Event.js`).
- Add distance/bearing helpers (`calculateDistanceMeters`, `calculateCompassDirection`, `formatVenueDistance`) and a `createLocationTracker` that wraps `navigator.geolocation.watchPosition` with a `subscribe`/`start` API (`src/js/app.js`).
- Update `getVenueDetail` to render the venue name plus a `.venue-distance` element that shows `160m SW` when available or a `Show distance` / `Retry location` button that starts the tracker and handles errors (`src/js/app.js`).
- Change `attachEventDetailsPanel` to accept the shared `locationTracker`, subscribe/unsubscribe per-opened event detail, and wire the tracker up during app initialization (`src/js/app.js`).
- Add styling for the distance text and the location request/retry button (`.venue-distance`, `.venue-distance-button`) in `src/css/style.css`.

### Testing
- Ran the build with `npm run build`, which completed successfully (webpack compiled without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52171daa70832bb6b3f78025c8d512)