### PR TITLE
Update settings panel and add venue sorting (official/A‑Z/distance/next-event)

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,67 +24,72 @@
     </header>
 
     <wa-drawer id="settingsPanel" class="settings-panel" label="Settings" placement="end">
-      <wa-card class="settings-card">
-        <wa-tab-group>
-          <wa-tab slot="nav" panel="favourites">Favourites</wa-tab>
-          <wa-tab slot="nav" panel="filters">Filters</wa-tab>
-          <wa-tab slot="nav" panel="install">Add to home screen</wa-tab>
-          <wa-tab slot="nav" panel="about">About</wa-tab>
+      <wa-tab-group class="settings-tabs">
+        <wa-tab slot="nav" panel="favourites">Favourites</wa-tab>
+        <wa-tab slot="nav" panel="filters">Filters</wa-tab>
+        <wa-tab slot="nav" panel="about">About</wa-tab>
 
-          <wa-tab-panel name="favourites">
-            <p>You need to manually re-import your favourites <em>whenever you change them</em>, but it only takes a second:</p>
-            <ol>
-              <li>Make sure you can see your favourites on the <a href="https://www.emfcamp.org/favourites" target="_blank">EMF site</a>.</li>
-              <li><a href="https://www.emfcamp.org/favourites.json" target="_blank">Long press or right click on this link</a>.</li>
-              <li>Select <em>Download link</em> or <em>Save Link As...</em></li>
-              <li>Upload the downloaded <code>favourites.json</code> file below.</li>
-            </ol>
-            <label class="field-stack">
-              <span>Upload favourites JSON</span>
-              <input type="file" id="favouritesJsonFileInput" accept=".json" />
+        <wa-tab-panel name="favourites">
+          <p>You need to manually re-import your favourites <em>whenever you change them</em>, but it only takes a second:</p>
+          <ol>
+            <li>Make sure you can see your favourites on the <a href="https://www.emfcamp.org/favourites" target="_blank">EMF site</a>.</li>
+            <li><a href="https://www.emfcamp.org/favourites.json" target="_blank">Long press or right click on this link</a>.</li>
+            <li>Select <em>Download link</em> or <em>Save Link As...</em></li>
+            <li>Upload the downloaded <code>favourites.json</code> file below.</li>
+          </ol>
+          <label class="field-stack">
+            <span>Upload favourites JSON</span>
+            <input type="file" id="favouritesJsonFileInput" accept=".json" />
+          </label>
+        </wa-tab-panel>
+
+        <wa-tab-panel name="filters">
+          <div class="event-filters">
+            <label class="checkbox-field">
+              <input type="checkbox" id="filterFavouritesOnly" />
+              <span>Favourites only</span>
             </label>
-          </wa-tab-panel>
+            <label class="field-stack">
+              <span>Type</span>
+              <select id="filterType">
+                <option value="">All types</option>
+              </select>
+            </label>
+            <label class="field-stack">
+              <span>Official</span>
+              <select id="filterOfficial">
+                <option value="">All events</option>
+                <option value="true">Official only</option>
+                <option value="false">Unofficial only</option>
+              </select>
+            </label>
+            <label class="field-stack">
+              <span>Venue</span>
+              <select id="filterVenue">
+                <option value="">All venues</option>
+              </select>
+            </label>
+            <label class="field-stack">
+              <span>Venue sort</span>
+              <select id="venueSort">
+                <option value="official">Official first</option>
+                <option value="az">A-Z</option>
+                <option value="distance">Distance</option>
+                <option value="next-event">Next event</option>
+              </select>
+            </label>
+            <wa-button type="button" id="resetFilters" appearance="outlined" variant="neutral">Reset filters</wa-button>
+          </div>
+        </wa-tab-panel>
 
-          <wa-tab-panel name="filters">
-            <div class="event-filters">
-              <label class="checkbox-field">
-                <input type="checkbox" id="filterFavouritesOnly" />
-                <span>Favourites only</span>
-              </label>
-              <label class="field-stack">
-                <span>Type</span>
-                <select id="filterType">
-                  <option value="">All types</option>
-                </select>
-              </label>
-              <label class="field-stack">
-                <span>Official</span>
-                <select id="filterOfficial">
-                  <option value="">All events</option>
-                  <option value="true">Official only</option>
-                  <option value="false">Unofficial only</option>
-                </select>
-              </label>
-              <label class="field-stack">
-                <span>Venue</span>
-                <select id="filterVenue">
-                  <option value="">All venues</option>
-                </select>
-              </label>
-              <wa-button type="button" id="resetFilters" appearance="outlined" variant="neutral">Reset filters</wa-button>
-            </div>
-          </wa-tab-panel>
-
-          <wa-tab-panel name="install">
-            <p>Tap your browser's menu or share button, then <strong>Install app</strong> or <strong>Add to Home screen</strong>.</p>
-          </wa-tab-panel>
-
-          <wa-tab-panel name="about">
-            <p>EMP helps you plan your time at Electromagnetic Field by showing the schedule on a 2D timetable.</p>
-            <p><a href="https://github.com/dave1010/emf-planner" target="_blank">View the project on GitHub</a>.</p>
-          </wa-tab-panel>
-        </wa-tab-group>
-      </wa-card>
+        <wa-tab-panel name="about">
+          <p>EMP helps you plan your time at Electromagnetic Field by showing the schedule on a 2D timetable.</p>
+          <p><a href="https://www.emfcamp.org/schedule/2026" target="_blank" rel="noopener noreferrer">View the official EMF 2026 schedule</a>.</p>
+          <p><a href="https://github.com/dave1010/emf-planner" target="_blank" rel="noopener noreferrer">View the project on GitHub</a>.</p>
+          <h2>Add to home screen</h2>
+          <p>Tap your browser's menu or share button, then <strong>Install app</strong> or <strong>Add to Home screen</strong>.</p>
+        </wa-tab-panel>
+      </wa-tab-group>
     </wa-drawer>
 
     <wa-split-panel id="eventSplitPanel" class="event-split-panel no-event-selected" orientation="vertical" position="100">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -74,37 +74,35 @@ h1 strong {
 
 .settings-panel::part(body) {
     background: rgba(23, 38, 14, 0.96);
-    padding: 1rem clamp(0.75rem, 2vw, 1.5rem);
+    padding: 0;
 }
 
-.settings-card {
-    --border-color: rgba(207, 204, 192, 0.28);
-    --border-radius: 0.85rem;
-    max-width: 56rem;
-    color: #1f241c;
+.settings-tabs {
+    display: block;
+    color: #fff;
 }
 
-.settings-card h2 {
+.settings-tabs h2 {
     margin: 0;
-    color: var(--dark-red);
+    color: var(--light-green);
     font-size: 1rem;
 }
 
-.settings-card wa-tab,
-.settings-card wa-tab-panel {
-    color: #1f241c;
+.settings-tabs wa-tab,
+.settings-tabs wa-tab-panel {
+    color: #fff;
 }
 
-.settings-card a {
+.settings-tabs a {
     color: var(--blue);
 }
 
-.settings-card p,
-.settings-card ol {
+.settings-tabs p,
+.settings-tabs ol {
     margin-top: 0;
 }
 
-.settings-card :is(input, select) {
+.settings-tabs :is(input, select) {
     border: 1px solid rgba(207, 204, 192, 0.5);
     border-radius: 0.45rem;
     background: rgba(255, 255, 255, 0.96);
@@ -126,7 +124,7 @@ h1 strong {
 
 .field-stack span,
 .checkbox-field span {
-    color: #27301f;
+    color: #fff;
     font-weight: 700;
 }
 

--- a/src/js/Schedule.js
+++ b/src/js/Schedule.js
@@ -40,7 +40,7 @@ class Schedule {
             this.venues[venueName] = new Venue(venueName);
             this.venues[venueName].events = [];
         }
-        this.venues[venueName].events.push(event);
+        this.venues[venueName].addEvent(event);
     }
 
     getVenues() {

--- a/src/js/Timeline.js
+++ b/src/js/Timeline.js
@@ -9,11 +9,13 @@ class Timeline {
     this.domElement = domElement;
     this.schedule = schedule;
     this.onEventSelect = onEventSelect;
+    this.userLatlon = null;
     this.filters = {
       favouritesOnly: false,
       type: '',
       official: '',
       venue: '',
+      venueSort: 'official',
     };
     this.render();
   }
@@ -31,6 +33,57 @@ class Timeline {
       ...filters,
     };
     this.render();
+  }
+
+  setUserLatlon(userLatlon) {
+    this.userLatlon = userLatlon;
+
+    if (this.filters.venueSort === 'distance') {
+      this.render();
+    }
+  }
+
+  getVenueDistance(venue) {
+    if (!this.userLatlon || !venue.latlon) {
+      return Number.POSITIVE_INFINITY;
+    }
+
+    const [fromLatitude, fromLongitude] = this.userLatlon;
+    const [toLatitude, toLongitude] = venue.latlon;
+    const latitudeDelta = toLatitude - fromLatitude;
+    const longitudeDelta = toLongitude - fromLongitude;
+
+    return (latitudeDelta ** 2) + (longitudeDelta ** 2);
+  }
+
+  sortVenues(venuesWithEvents) {
+    const sortByName = (a, b) => a.venue.name.localeCompare(b.venue.name);
+
+    return [...venuesWithEvents].sort((a, b) => {
+      if (this.filters.venueSort === 'az') {
+        return sortByName(a, b);
+      }
+
+      if (this.filters.venueSort === 'distance') {
+        return this.getVenueDistance(a.venue) - this.getVenueDistance(b.venue) || sortByName(a, b);
+      }
+
+      if (this.filters.venueSort === 'next-event') {
+        const now = Date.now();
+        const aNext = a.venue.nextEventAfter(now, a.events);
+        const bNext = b.venue.nextEventAfter(now, b.events);
+        const aTime = aNext ? aNext.start_date.getTime() : Number.POSITIVE_INFINITY;
+        const bTime = bNext ? bNext.start_date.getTime() : Number.POSITIVE_INFINITY;
+
+        return aTime - bTime || sortByName(a, b);
+      }
+
+      if (a.venue.isOfficial !== b.venue.isOfficial) {
+        return a.venue.isOfficial ? -1 : 1;
+      }
+
+      return sortByName(a, b);
+    });
   }
 
   eventMatchesFilters(event) {
@@ -70,13 +123,15 @@ class Timeline {
     const hoursTicksRow = new HoursTicksRow(startTime, endTime);
     this.domElement.appendChild(hoursTicksRow.domElement);
 
-    // Create timeline rows for each venue
-    for (const venue of this.schedule.getVenues()) {
-      const filteredEvents = venue.events.filter(event => this.eventMatchesFilters(event));
+    const venuesWithEvents = this.schedule.getVenues()
+      .map(venue => ({
+        venue,
+        events: venue.events.filter(event => this.eventMatchesFilters(event)),
+      }))
+      .filter(({ events }) => events.length > 0);
 
-      if (filteredEvents.length === 0) {
-        continue;
-      }
+    // Create timeline rows for each venue
+    for (const { venue, events: filteredEvents } of this.sortVenues(venuesWithEvents)) {
 
       // <div class="timeline-row"><div class="venue-details"></div><div class="events"></div></div>
 

--- a/src/js/Venue.js
+++ b/src/js/Venue.js
@@ -1,6 +1,32 @@
 class Venue {
     constructor(name) {
       this.name = name;
+      this.events = [];
+    }
+
+    addEvent(event) {
+      this.events.push(event);
+    }
+
+    get isOfficial() {
+      return this.events.some(event => event.isOfficial);
+    }
+
+    get latlon() {
+      return this.events.find(event => event.latlon)?.latlon || null;
+    }
+
+    nextEventAfter(date, events = this.events) {
+      const timestamp = date instanceof Date ? date.getTime() : Number(date);
+      const futureEvents = events.filter(event => event.start_date.getTime() >= timestamp);
+
+      if (futureEvents.length === 0) {
+        return null;
+      }
+
+      return futureEvents.reduce((earliest, event) => (
+        event.start_date < earliest.start_date ? event : earliest
+      ));
     }
 }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -260,11 +260,12 @@ const attachEventDetailsPanel = (locationTracker) => {
   };
 };
 
-const attachEventFilters = (timeline, schedule) => {
+const attachEventFilters = (timeline, schedule, locationTracker) => {
   const favouritesOnlyInput = document.getElementById('filterFavouritesOnly');
   const typeInput = document.getElementById('filterType');
   const officialInput = document.getElementById('filterOfficial');
   const venueInput = document.getElementById('filterVenue');
+  const venueSortInput = document.getElementById('venueSort');
   const resetButton = document.getElementById('resetFilters');
 
   addOptions(typeInput, schedule.getEventTypes());
@@ -276,10 +277,15 @@ const attachEventFilters = (timeline, schedule) => {
       type: typeInput.value,
       official: officialInput.value,
       venue: venueInput.value,
+      venueSort: venueSortInput.value,
     });
+
+    if (venueSortInput.value === 'distance') {
+      locationTracker.start();
+    }
   };
 
-  [favouritesOnlyInput, typeInput, officialInput, venueInput].forEach(input => {
+  [favouritesOnlyInput, typeInput, officialInput, venueInput, venueSortInput].forEach(input => {
     input.addEventListener('change', applyFilters);
   });
 
@@ -288,6 +294,7 @@ const attachEventFilters = (timeline, schedule) => {
     typeInput.value = '';
     officialInput.value = '';
     venueInput.value = '';
+    venueSortInput.value = 'official';
     applyFilters();
   });
 };
@@ -312,7 +319,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const showEventDetails = attachEventDetailsPanel(locationTracker);
   const timelineElement = document.getElementById('timeline');
   const timeline = new Timeline(timelineElement, schedule, showEventDetails);
-  attachEventFilters(timeline, schedule);
+  locationTracker.subscribe(({ position }) => timeline.setUserLatlon(position));
+  attachEventFilters(timeline, schedule, locationTracker);
 
   // go to 1 hour ago
   timeline.goToTime(Date.now() - 60 * 60 * 1000);


### PR DESCRIPTION
### Motivation
- Remove the extra card wrapper and unused spacing in the settings drawer to make the panel more compact while keeping the existing tabs. 
- Move the "Add to home screen" instructions into the About tab and add a link to the official EMF 2026 schedule. 
- Provide venue sorting options in Filters so users can reorder timetable rows by official-first, alphabetic, distance (via device geolocation), or next event.

### Description
- Replaced the `wa-card` wrapper with a tabbed group (`<wa-tab-group class="settings-tabs">`) and tightened drawer spacing by setting `.settings-panel::part(body)` padding to `0` and adjusting tab styles in `index.html` and `src/css/style.css`. 
- Moved the Add-to-home-screen content into the About tab and added the official schedule link (`https://www.emfcamp.org/schedule/2026`) in `index.html`. 
- Added a `Venue sort` control (`<select id="venueSort">`) with options `official`, `az`, `distance`, and `next-event` in the Filters section of `index.html`. 
- Extended venue model and schedule plumbing: added `events` storage and `addEvent`, `isOfficial`, `latlon`, and `nextEventAfter` helpers to `src/js/Venue.js`, and switched `Schedule.addEvent` to call `Venue.addEvent`. 
- Implemented sorting in the timeline: added `venueSort` to `Timeline` filters, `setUserLatlon`, `getVenueDistance`, and `sortVenues` to support the four sort modes and used the sorted venue list when rendering in `src/js/Timeline.js`. 
- Wired UI to timeline and geolocation: added `venueSort` handling to `attachEventFilters` in `src/js/app.js`, start geolocation watching when `distance` sort is selected, and subscribe `locationTracker` to call `timeline.setUserLatlon(position)` so distance sorting updates live.

### Testing
- Ran `npm run build`, which compiled successfully via webpack with no errors. 
- Ran `git diff --check` to validate whitespace/formatting issues and received no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a521ab687e0832b846238407f8f635a)