### PR TITLE
Sticky day labels, midday jump buttons, event countdowns & settings contrast fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       <h1><strong>E</strong>lectro<strong>M</strong>agnetic Field <strong>P</strong>lanner</h1>
 
       <nav class="header-actions" aria-label="Planner actions">
+        <div id="middayJumpButtons" class="midday-jump-buttons" role="group" aria-label="Skip to midday"></div>
         <wa-button id="settingsToggle" appearance="filled" variant="brand" size="small" aria-label="Open settings" title="Settings" aria-expanded="false" aria-controls="settingsPanel">
           <span aria-hidden="true">⚙</span>
         </wa-button>
@@ -24,12 +25,12 @@
     </header>
 
     <wa-drawer id="settingsPanel" class="settings-panel" label="Settings" placement="end">
-      <wa-tab-group class="settings-tabs">
-        <wa-tab slot="nav" panel="favourites">Favourites</wa-tab>
+      <wa-tab-group class="settings-tabs" active="favourites">
+        <wa-tab slot="nav" panel="favourites" active>Favourites</wa-tab>
         <wa-tab slot="nav" panel="filters">Filters</wa-tab>
         <wa-tab slot="nav" panel="about">About</wa-tab>
 
-        <wa-tab-panel name="favourites">
+        <wa-tab-panel name="favourites" active>
           <p>You need to manually re-import your favourites <em>whenever you change them</em>, but it only takes a second:</p>
           <ol>
             <li>Make sure you can see your favourites on the <a href="https://www.emfcamp.org/favourites" target="_blank">EMF site</a>.</li>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -70,6 +70,43 @@ h1 strong {
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.midday-jump-buttons {
+    display: inline-flex;
+    overflow: hidden;
+    border: 1px solid rgba(207, 204, 192, 0.45);
+    border-radius: 0.5rem;
+}
+
+.midday-jump-button {
+    min-width: 1.8rem;
+    border: 0;
+    border-right: 1px solid rgba(207, 204, 192, 0.28);
+    background: rgba(207, 204, 192, 0.12);
+    color: #fff;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0.45rem 0.5rem;
+}
+
+.midday-jump-button:last-child {
+    border-right: 0;
+}
+
+.midday-jump-button:hover,
+.midday-jump-button:focus-visible {
+    background: var(--light-green);
+    color: var(--dark-green);
+}
+
+.settings-panel::part(header),
+.settings-panel::part(title) {
+    background: var(--dark-red);
+    color: #fff;
 }
 
 .settings-panel::part(body) {
@@ -102,7 +139,11 @@ h1 strong {
     margin-top: 0;
 }
 
-.settings-tabs :is(input, select) {
+.settings-tabs input[type="checkbox"] {
+    accent-color: var(--light-green);
+}
+
+.settings-tabs :is(input:not([type="checkbox"]), select) {
     border: 1px solid rgba(207, 204, 192, 0.5);
     border-radius: 0.45rem;
     background: rgba(255, 255, 255, 0.96);
@@ -205,6 +246,17 @@ h1 strong {
 
 .timeline-header-row .hour, .timeline-header-row .day {
     padding: 0 5px;
+}
+
+.timeline-header-row .day {
+    box-sizing: border-box;
+    overflow: clip;
+}
+
+.timeline-header-row .day-label {
+    position: sticky;
+    left: 4px;
+    display: inline-block;
 }
 
 /* fixed to left */

--- a/src/js/DaysRow.js
+++ b/src/js/DaysRow.js
@@ -15,7 +15,10 @@ class DayBlock extends TimelineBlock {
         const dayBlock = document.createElement('div');
         dayBlock.className = 'day';
         dayBlock.classList.add('timeline-block');
-        dayBlock.innerText = this.startDate.toLocaleDateString('en-GB', { weekday: 'short' });
+        const dayLabel = document.createElement('span');
+        dayLabel.className = 'day-label';
+        dayLabel.innerText = this.startDate.toLocaleDateString('en-GB', { weekday: 'short' });
+        dayBlock.appendChild(dayLabel);
 
         // Generate a background color based on the day of the week
         dayBlock.style.backgroundColor = `hsla(${(this.startDate.getDay() * 40) % 360}, 50%, 30%, 1)`;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -81,7 +81,8 @@ const formatVenueDistance = (userLatlon, venueLatlon) => {
 
   const distance = Math.round(calculateDistanceMeters(userLatlon, venueLatlon));
   const direction = calculateCompassDirection(userLatlon, venueLatlon);
-  return `${distance}m ${direction}`;
+  const walkingMinutes = Math.max(1, Math.ceil(distance / 84));
+  return `${distance}m ${direction} 🚶${walkingMinutes}min`;
 };
 
 const createLocationTracker = () => {
@@ -135,6 +136,37 @@ const formatEventDayTime = (date) => new Intl.DateTimeFormat(undefined, {
   hour: '2-digit',
   minute: '2-digit',
 }).format(date);
+
+const formatCountdownDuration = (milliseconds) => {
+  const totalMinutes = Math.max(0, Math.ceil(milliseconds / (60 * 1000)));
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [];
+
+  if (days) {
+    parts.push(`${days}d`);
+  }
+
+  if (hours || days) {
+    parts.push(`${hours}h`);
+  }
+
+  parts.push(`${minutes}m`);
+  return parts.join(' ');
+};
+
+const formatEventCountdown = (event, now = new Date()) => {
+  if (now < event.start_date) {
+    return `Starts in ${formatCountdownDuration(event.start_date - now)}`;
+  }
+
+  if (now < event.end_date) {
+    return `Ends in ${formatCountdownDuration(event.end_date - now)}`;
+  }
+
+  return '';
+};
 
 const appendDetail = (detailsList, label, value) => {
   if (!value) {
@@ -243,7 +275,11 @@ const attachEventDetailsPanel = (locationTracker) => {
     titleIcon.setAttribute('variant', 'solid');
     title.append(document.createTextNode(`${event.title} `), titleIcon);
     title.href = event.link;
-    time.innerText = `${formatEventDayTime(event.start_date)}–${formatEventDayTime(event.end_date)}`;
+    const countdown = formatEventCountdown(event);
+    time.innerText = [
+      `${formatEventDayTime(event.start_date)}–${formatEventDayTime(event.end_date)}`,
+      countdown,
+    ].filter(Boolean).join(' · ');
     detailsList.innerHTML = '';
     text.innerHTML = '';
     const venueDetail = getVenueDetail(event, locationTracker);
@@ -258,6 +294,36 @@ const attachEventDetailsPanel = (locationTracker) => {
     splitPanel.classList.remove('no-event-selected');
     splitPanel.position = 60;
   };
+};
+
+
+const attachMiddayJumpButtons = (timeline, schedule) => {
+  const container = document.getElementById('middayJumpButtons');
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+  const startTime = schedule.getStartDate();
+  const endTime = schedule.getEndDate();
+  const currentDate = new Date(startTime);
+  currentDate.setHours(12, 0, 0, 0);
+
+  if (currentDate < startTime) {
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  while (currentDate < endTime) {
+    const buttonDate = new Date(currentDate);
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'midday-jump-button';
+    button.innerText = buttonDate.toLocaleDateString('en-GB', { weekday: 'narrow' });
+    button.title = `Skip to midday on ${buttonDate.toLocaleDateString('en-GB', { weekday: 'long', month: 'short', day: 'numeric' })}`;
+    button.addEventListener('click', () => timeline.goToTime(buttonDate));
+    container.appendChild(button);
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
 };
 
 const attachEventFilters = (timeline, schedule, locationTracker) => {
@@ -319,6 +385,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const showEventDetails = attachEventDetailsPanel(locationTracker);
   const timelineElement = document.getElementById('timeline');
   const timeline = new Timeline(timelineElement, schedule, showEventDetails);
+  attachMiddayJumpButtons(timeline, schedule);
   locationTracker.subscribe(({ position }) => timeline.setUserLatlon(position));
   attachEventFilters(timeline, schedule, locationTracker);
 


### PR DESCRIPTION
### Motivation
- Keep the day-of-week visible while horizontally scrolling the timeline so users always know which day they are viewing. 
- Provide a quick way to jump the timeline to mid-day for each schedule day to speed navigation. 
- Surface relative timing and approximate walking time in the event details to help users decide which events to attend. 
- Fix settings drawer contrast and ensure the first tab is visible/selected by default so the UI is usable on dark backgrounds.

### Description
- Added a small header group `#middayJumpButtons` and an `attachMiddayJumpButtons` function that generates per-day buttons which call `timeline.goToTime(...)` to jump to midday. (files changed: `index.html`, `src/js/app.js`, `src/css/style.css`).
- Made the timeline day label a dedicated span (`.day-label`) in `DaysRow.js` and applied sticky positioning so the day label remains visible while scrolling horizontally. (file changed: `src/js/DaysRow.js`, `src/css/style.css`).
- Introduced `formatEventCountdown` / `formatCountdownDuration` and appended a countdown string to the event details time line so future/ongoing events show `Starts in ...` or `Ends in ...`. (file changed: `src/js/app.js`).
- Extended `formatVenueDistance` to include an approximate walking time (rounded up minutes with the 🚶 emoji) and adjusted CSS to improve settings drawer contrast and make the favourites checkbox visible via `accent-color`. (files changed: `src/js/app.js`, `src/css/style.css`, `index.html` to default the Favourites tab to active).

### Testing
- Built the project with `npm run build` and the Webpack build completed successfully. 
- The modified files compiled into the bundled assets without errors (`app.*.js`, `style.*.js`, `index.html` were emitted by the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5246c2de18832bb416c85417637427)