### PR TITLE
Improve filters and day picker layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <wa-drawer id="settingsPanel" class="settings-panel" label="Settings" placement="end">
       <wa-tab-group class="settings-tabs" active="favourites">
         <wa-tab slot="nav" panel="favourites" active>Favourites</wa-tab>
-        <wa-tab slot="nav" panel="filters">Filters</wa-tab>
+        <wa-tab slot="nav" panel="filters">Filters <span id="filtersActiveIndicator" class="filters-active-indicator" hidden>●</span></wa-tab>
         <wa-tab slot="nav" panel="about">About</wa-tab>
 
         <wa-tab-panel name="favourites" active>
@@ -70,16 +70,16 @@
                 <option value="">All venues</option>
               </select>
             </label>
-            <label class="field-stack">
-              <span>Venue sort</span>
-              <select id="venueSort">
-                <option value="official">Official first</option>
-                <option value="az">A-Z</option>
-                <option value="distance">Distance</option>
-                <option value="next-event">Next event</option>
-              </select>
-            </label>
-            <wa-button type="button" id="resetFilters" appearance="outlined" variant="neutral">Reset filters</wa-button>
+            <fieldset class="field-stack venue-sort-field">
+              <legend>Venue sort</legend>
+              <div id="venueSort" class="venue-sort-buttons" role="radiogroup" aria-label="Venue sort">
+                <button type="button" class="venue-sort-button" data-value="official" aria-pressed="true">Official first</button>
+                <button type="button" class="venue-sort-button" data-value="az" aria-pressed="false">A-Z</button>
+                <button type="button" class="venue-sort-button" data-value="distance" aria-pressed="false">Distance</button>
+                <button type="button" class="venue-sort-button" data-value="next-event" aria-pressed="false">Next event</button>
+              </div>
+            </fieldset>
+            <wa-button type="button" id="resetFilters" class="reset-filters-button" appearance="filled" variant="brand">Reset filters</wa-button>
           </div>
         </wa-tab-panel>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -49,7 +49,7 @@ a {
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
     border-bottom: 1px solid rgba(207, 204, 192, 0.25);
     box-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
     z-index: 3;
@@ -81,7 +81,7 @@ h1 strong {
 }
 
 .midday-jump-button {
-    min-width: 1.8rem;
+    min-width: 1.55rem;
     border: 0;
     border-right: 1px solid rgba(207, 204, 192, 0.28);
     background: rgba(207, 204, 192, 0.12);
@@ -90,7 +90,7 @@ h1 strong {
     font: inherit;
     font-weight: 700;
     line-height: 1;
-    padding: 0.45rem 0.5rem;
+    padding: 0.35rem 0.42rem;
 }
 
 .midday-jump-button:last-child {
@@ -130,6 +130,15 @@ h1 strong {
     color: #fff;
 }
 
+.settings-tabs wa-tab-panel {
+    padding: 0.85rem 1rem 1rem;
+}
+
+.filters-active-indicator {
+    color: var(--light-green);
+    font-size: 0.85em;
+}
+
 .settings-tabs a {
     color: var(--blue);
 }
@@ -159,11 +168,19 @@ h1 strong {
     gap: 0.5rem;
 }
 
+.event-filters .field-stack {
+    display: grid;
+    grid-template-columns: minmax(6.5rem, max-content) minmax(0, 1fr);
+    align-items: center;
+    column-gap: 0.75rem;
+}
+
 .event-filters {
     gap: 0.75rem;
 }
 
 .field-stack span,
+.field-stack legend,
 .checkbox-field span {
     color: #fff;
     font-weight: 700;
@@ -175,9 +192,68 @@ h1 strong {
     gap: 0.6rem;
 }
 
+.venue-sort-field {
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+.venue-sort-field legend {
+    padding: 0;
+}
+
+.venue-sort-buttons {
+    display: inline-flex;
+    flex-wrap: wrap;
+    overflow: hidden;
+    border: 1px solid rgba(207, 204, 192, 0.5);
+    border-radius: 0.5rem;
+}
+
+.venue-sort-button {
+    border: 0;
+    border-right: 1px solid rgba(207, 204, 192, 0.35);
+    background: rgba(207, 204, 192, 0.12);
+    color: #fff;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    padding: 0.45rem 0.6rem;
+}
+
+.venue-sort-button:last-child {
+    border-right: 0;
+}
+
+.venue-sort-button[aria-pressed="true"] {
+    background: var(--light-green);
+    color: var(--dark-green);
+}
+
+.venue-sort-button:hover,
+.venue-sort-button:focus-visible {
+    background: var(--cream);
+    color: var(--dark-green);
+}
+
+.reset-filters-button::part(base) {
+    background: var(--blue);
+    border-color: var(--blue);
+    color: #fff;
+}
+
+.reset-filters-button::part(base):hover {
+    background: #2380a0;
+    border-color: #2380a0;
+}
+
 @media (max-width: 700px) {
     .app-header {
         gap: 0.5rem;
+    }
+
+    .event-filters .field-stack {
+        grid-template-columns: 1fr;
     }
 }
 /************** TIMELINE **************/

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -41,6 +41,14 @@ const GEOLOCATION_OPTIONS = {
   maximumAge: 15000,
   timeout: 10000,
 };
+const FILTERS_STORAGE_KEY = 'emf-planner:event-filters';
+const DEFAULT_FILTERS = {
+  favouritesOnly: false,
+  type: '',
+  official: '',
+  venue: '',
+  venueSort: 'official',
+};
 
 const toRadians = (degrees) => degrees * Math.PI / 180;
 const toDegrees = (radians) => radians * 180 / Math.PI;
@@ -313,8 +321,15 @@ const attachMiddayJumpButtons = (timeline, schedule) => {
     currentDate.setDate(currentDate.getDate() + 1);
   }
 
+  const buttonDates = [];
+
   while (currentDate < endTime) {
-    const buttonDate = new Date(currentDate);
+    buttonDates.push(new Date(currentDate));
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  // The final schedule day only contains events spilling past midnight, so omit it from the jump picker.
+  buttonDates.slice(0, -1).forEach(buttonDate => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'midday-jump-button';
@@ -322,9 +337,34 @@ const attachMiddayJumpButtons = (timeline, schedule) => {
     button.title = `Skip to midday on ${buttonDate.toLocaleDateString('en-GB', { weekday: 'long', month: 'short', day: 'numeric' })}`;
     button.addEventListener('click', () => timeline.goToTime(buttonDate));
     container.appendChild(button);
-    currentDate.setDate(currentDate.getDate() + 1);
+  });
+};
+
+const loadStoredFilters = () => {
+  try {
+    return {
+      ...DEFAULT_FILTERS,
+      ...JSON.parse(window.localStorage.getItem(FILTERS_STORAGE_KEY) || '{}'),
+    };
+  } catch (error) {
+    return { ...DEFAULT_FILTERS };
   }
 };
+
+const saveFilters = (filters) => {
+  window.localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(filters));
+};
+
+const setVenueSortValue = (venueSortInput, value) => {
+  const buttons = [...venueSortInput.querySelectorAll('.venue-sort-button')];
+  const nextValue = buttons.some(button => button.dataset.value === value) ? value : DEFAULT_FILTERS.venueSort;
+  venueSortInput.dataset.value = nextValue;
+  buttons.forEach(button => {
+    button.setAttribute('aria-pressed', String(button.dataset.value === nextValue));
+  });
+};
+
+const getVenueSortValue = (venueSortInput) => venueSortInput.dataset.value || DEFAULT_FILTERS.venueSort;
 
 const attachEventFilters = (timeline, schedule, locationTracker) => {
   const favouritesOnlyInput = document.getElementById('filterFavouritesOnly');
@@ -332,37 +372,64 @@ const attachEventFilters = (timeline, schedule, locationTracker) => {
   const officialInput = document.getElementById('filterOfficial');
   const venueInput = document.getElementById('filterVenue');
   const venueSortInput = document.getElementById('venueSort');
+  const filtersActiveIndicator = document.getElementById('filtersActiveIndicator');
   const resetButton = document.getElementById('resetFilters');
 
   addOptions(typeInput, schedule.getEventTypes());
   addOptions(venueInput, schedule.getVenueNames());
 
-  const applyFilters = () => {
-    timeline.setFilters({
+  const applyFilters = ({ persist = true } = {}) => {
+    const filters = {
       favouritesOnly: favouritesOnlyInput.checked,
       type: typeInput.value,
       official: officialInput.value,
       venue: venueInput.value,
-      venueSort: venueSortInput.value,
-    });
+      venueSort: getVenueSortValue(venueSortInput),
+    };
 
-    if (venueSortInput.value === 'distance') {
+    timeline.setFilters(filters);
+
+    const hasActiveFilters = filters.favouritesOnly || filters.type || filters.official || filters.venue;
+    filtersActiveIndicator.hidden = !hasActiveFilters;
+    filtersActiveIndicator.title = hasActiveFilters ? 'Events are currently filtered' : '';
+
+    if (persist) {
+      saveFilters(filters);
+    }
+
+    if (filters.venueSort === 'distance') {
       locationTracker.start();
     }
   };
 
-  [favouritesOnlyInput, typeInput, officialInput, venueInput, venueSortInput].forEach(input => {
+  const storedFilters = loadStoredFilters();
+  favouritesOnlyInput.checked = Boolean(storedFilters.favouritesOnly);
+  typeInput.value = storedFilters.type;
+  officialInput.value = storedFilters.official;
+  venueInput.value = storedFilters.venue;
+  setVenueSortValue(venueSortInput, storedFilters.venueSort || DEFAULT_FILTERS.venueSort);
+
+  [favouritesOnlyInput, typeInput, officialInput, venueInput].forEach(input => {
     input.addEventListener('change', applyFilters);
   });
 
+  venueSortInput.querySelectorAll('.venue-sort-button').forEach(button => {
+    button.addEventListener('click', () => {
+      setVenueSortValue(venueSortInput, button.dataset.value);
+      applyFilters();
+    });
+  });
+
   resetButton.addEventListener('click', () => {
-    favouritesOnlyInput.checked = false;
-    typeInput.value = '';
-    officialInput.value = '';
-    venueInput.value = '';
-    venueSortInput.value = 'official';
+    favouritesOnlyInput.checked = DEFAULT_FILTERS.favouritesOnly;
+    typeInput.value = DEFAULT_FILTERS.type;
+    officialInput.value = DEFAULT_FILTERS.official;
+    venueInput.value = DEFAULT_FILTERS.venue;
+    setVenueSortValue(venueSortInput, DEFAULT_FILTERS.venueSort);
     applyFilters();
   });
+
+  applyFilters({ persist: false });
 };
 
 document.addEventListener('DOMContentLoaded', async () => {


### PR DESCRIPTION
### Motivation

- Prevent the header overflowing to two lines by compacting the weekday picker and omitting the final schedule day that only contains spillover events.
- Make venue sorting more discoverable by defaulting to “Official first” and replacing the select with a button-group control.
- Preserve users’ filter and sort choices across sessions so the UI restores state on page load.
- Improve the Filters tab usability by aligning labels and controls, adding spacing inside tab panels, showing an active-filter indicator, and making the Reset button higher-contrast.

### Description

- Replace the venue sort `<select>` with a button-group (`fieldset` + buttons) and wire click handling in `src/js/app.js` to set `aria-pressed` state; add `setVenueSortValue`/`getVenueSortValue` helpers and default to `official`.
- Compact and regenerate the midday jump buttons in `attachMiddayJumpButtons` to use narrow weekday labels and omit the final spillover-only day (`src/js/app.js`).
- Persist and restore filters (including venue sort) using `localStorage` via `loadStoredFilters`/`saveFilters` and apply restored filters on load (`src/js/app.js`); add a visual indicator element in `index.html` and toggle it when filters are active.
- Update styling in `src/css/style.css` to reduce header spacing, tighten the midday-jump button sizing, add padding inside settings tab panels, align filter controls using a grid, style the venue-sort button group, and improve the Reset button contrast.
- Files changed: `index.html`, `src/js/app.js`, `src/css/style.css`.

### Testing

- Ran `npm run build` and the project compiled successfully (`webpack` completed without errors).
- Ran `git diff --check` which reported no whitespace or merge problems.
- Attempted a headless/browser check but Playwright/Chromium was not available in the environment so no end-to-end browser test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5269166aec832bb7c994a32b1eebd4)