### PR TITLE
Add offline schedule support

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             <li>Select <em>Download link</em> or <em>Save Link As...</em></li>
             <li>Upload the downloaded <code>favourites.json</code> file below.</li>
           </ol>
+          <p id="favouritesSyncStatus" class="sync-status">Favourites have not been imported on this device yet.</p>
           <label class="field-stack">
             <span>Upload favourites JSON</span>
             <input type="file" id="favouritesJsonFileInput" accept=".json" />
@@ -86,6 +87,11 @@
         <wa-tab-panel name="about">
           <p>EMP helps you plan your time at Electromagnetic Field by showing the schedule on a 2D timetable.</p>
           <p><a href="https://www.emfcamp.org/schedule/2026" target="_blank" rel="noopener noreferrer">View the official EMF 2026 schedule</a>.</p>
+          <section class="schedule-refresh" aria-labelledby="scheduleRefreshHeading">
+            <h2 id="scheduleRefreshHeading">Schedule data</h2>
+            <p id="scheduleRefreshStatus" class="sync-status">Checking schedule freshness…</p>
+            <wa-button type="button" id="refreshSchedule" appearance="filled" variant="brand">Refresh schedule now</wa-button>
+          </section>
           <p><a href="https://github.com/dave1010/emf-planner" target="_blank" rel="noopener noreferrer">View the project on GitHub</a>.</p>
           <h2>Add to home screen</h2>
           <p>Tap your browser's menu or share button, then <strong>Install app</strong> or <strong>Add to Home screen</strong>.</p>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -505,7 +505,6 @@ h1 strong {
 }
 
 .sync-status {
-    border-left: 0.25rem solid var(--light-green);
     background: rgba(207, 204, 192, 0.12);
     border-radius: 0.35rem;
     padding: 0.55rem 0.65rem;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -503,3 +503,20 @@ h1 strong {
     background: var(--light-green);
     color: var(--dark-green);
 }
+
+.sync-status {
+    border-left: 0.25rem solid var(--light-green);
+    background: rgba(207, 204, 192, 0.12);
+    border-radius: 0.35rem;
+    padding: 0.55rem 0.65rem;
+}
+
+.schedule-refresh {
+    display: grid;
+    gap: 0.6rem;
+    margin: 1rem 0;
+}
+
+.schedule-refresh .sync-status {
+    margin: 0;
+}

--- a/src/js/FavouritesDatabase.js
+++ b/src/js/FavouritesDatabase.js
@@ -8,6 +8,7 @@ class FavouritesDatabase {
     this.storage = storage; // window.localStorage
     this.key = key;
     this.favourites = []; // list of IDs
+    this.syncedAt = null;
     this.schedule = schedule;
 
     this.load();
@@ -16,6 +17,7 @@ class FavouritesDatabase {
   load() {
     const json = this.storage.getItem(this.key);
     this.favourites = json ? JSON.parse(json) : [];
+    this.syncedAt = this.storage.getItem(`${this.key}:syncedAt`);
     this.schedule.setFavourites(this.favourites);
   }
 
@@ -23,7 +25,13 @@ class FavouritesDatabase {
     const json = JSON.stringify(listOfIds);
     this.favourites = listOfIds;
     this.storage.setItem(this.key, json);
+    this.syncedAt = new Date().toISOString();
+    this.storage.setItem(`${this.key}:syncedAt`, this.syncedAt);
     this.schedule.setFavourites(this.favourites);
+  }
+
+  getSyncedAt() {
+    return this.syncedAt;
   }
 
   attachToFileInput(fileInput, onSave = null) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,13 +2,115 @@ import Schedule from "./Schedule.js";
 import Timeline from "./Timeline.js";
 import FavouritesDatabase from "./FavouritesDatabase.js";
 
-const fetchData = async (url) => {
+const SCHEDULE_URL = 'https://www.emfcamp.org/schedule/2026.json';
+const SCHEDULE_STORAGE_KEY = 'emf-planner:schedule-data';
+const SCHEDULE_METADATA_STORAGE_KEY = 'emf-planner:schedule-metadata';
+
+const readJsonStorage = (key, fallback = null) => {
   try {
-    const response = await fetch(url);
-    return await response.ok ? response.json() : null;
+    const value = window.localStorage.getItem(key);
+    return value ? JSON.parse(value) : fallback;
   } catch (error) {
-    return null;
+    return fallback;
   }
+};
+
+const writeJsonStorage = (key, value) => {
+  window.localStorage.setItem(key, JSON.stringify(value));
+};
+
+const fetchJson = async (url, { cache = 'default' } = {}) => {
+  const response = await fetch(url, { cache });
+  return response.ok ? response.json() : null;
+};
+
+const loadScheduleData = async ({ forceRefresh = false } = {}) => {
+  try {
+    const data = await fetchJson(SCHEDULE_URL, { cache: forceRefresh ? 'reload' : 'default' });
+
+    if (data) {
+      const metadata = {
+        fetchedAt: new Date().toISOString(),
+        source: 'network',
+      };
+      writeJsonStorage(SCHEDULE_STORAGE_KEY, data);
+      writeJsonStorage(SCHEDULE_METADATA_STORAGE_KEY, metadata);
+      return { data, metadata, fromCache: false };
+    }
+  } catch (error) {
+    // Fall back to the locally stored copy below.
+  }
+
+  const data = readJsonStorage(SCHEDULE_STORAGE_KEY);
+  const metadata = readJsonStorage(SCHEDULE_METADATA_STORAGE_KEY);
+  return data ? { data, metadata: { ...metadata, source: 'local' }, fromCache: true } : null;
+};
+
+const registerServiceWorker = () => {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  navigator.serviceWorker.register('/service-worker.js').catch(() => {
+    // Offline support is best-effort on unsupported or restricted browsers.
+  });
+};
+
+
+const formatDateTime = (date) => new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+}).format(date);
+
+const formatAge = (date, now = new Date()) => {
+  const seconds = Math.max(0, Math.floor((now - date) / 1000));
+  const units = [
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60],
+  ];
+
+  for (const [unit, unitSeconds] of units) {
+    const value = Math.floor(seconds / unitSeconds);
+    if (value >= 1) {
+      return `${value} ${unit}${value === 1 ? '' : 's'} ago`;
+    }
+  }
+
+  return 'just now';
+};
+
+const describeTimestamp = (isoTimestamp, emptyText) => {
+  if (!isoTimestamp) {
+    return emptyText;
+  }
+
+  const date = new Date(isoTimestamp);
+  if (Number.isNaN(date.getTime())) {
+    return emptyText;
+  }
+
+  return `${formatDateTime(date)} (${formatAge(date)})`;
+};
+
+const updateScheduleRefreshStatus = (metadata, { fromCache = false, message = '' } = {}) => {
+  const status = document.getElementById('scheduleRefreshStatus');
+  if (!status) {
+    return;
+  }
+
+  const timestamp = describeTimestamp(metadata?.fetchedAt, 'No schedule data has been cached on this device yet.');
+  const source = fromCache || metadata?.source === 'local' ? 'Using cached schedule data.' : 'Schedule data is up to date.';
+  status.innerText = message || `${source} Last refresh: ${timestamp}`;
+};
+
+const updateFavouritesSyncStatus = (favouritesDatabase) => {
+  const status = document.getElementById('favouritesSyncStatus');
+  if (!status) {
+    return;
+  }
+
+  status.innerText = `Last favourites import: ${describeTimestamp(favouritesDatabase.getSyncedAt(), 'never on this device')}.`;
 };
 
 const addOptions = (selectElement, values) => {
@@ -433,20 +535,29 @@ const attachEventFilters = (timeline, schedule, locationTracker) => {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
+  registerServiceWorker();
   attachSettingsToggle();
 
-  const data = await fetchData('https://www.emfcamp.org/schedule/2026.json');
+  const scheduleResult = await loadScheduleData();
 
-  if (!data) {
-    alert('Failed to load schedule data')
+  if (!scheduleResult) {
+    updateScheduleRefreshStatus(null, { message: 'Schedule data could not be loaded. Connect to the internet and try Refresh schedule now.' });
+    document.getElementById('timeline').innerText = 'Failed to load schedule data.';
+    return;
   }
 
-  const schedule = Schedule.createFromJson(data);
+  updateScheduleRefreshStatus(scheduleResult.metadata, { fromCache: scheduleResult.fromCache });
+
+  const schedule = Schedule.createFromJson(scheduleResult.data);
 
   const favouritesDatabase = new FavouritesDatabase(window.localStorage, 'favourites', schedule);
+  updateFavouritesSyncStatus(favouritesDatabase);
   
   const favouritesFileInput = document.getElementById('favouritesJsonFileInput');
-  favouritesDatabase.attachToFileInput(favouritesFileInput, () => timeline.render());
+  favouritesDatabase.attachToFileInput(favouritesFileInput, () => {
+    updateFavouritesSyncStatus(favouritesDatabase);
+    timeline.render();
+  });
 
   const locationTracker = createLocationTracker();
   const showEventDetails = attachEventDetailsPanel(locationTracker);
@@ -456,8 +567,21 @@ document.addEventListener('DOMContentLoaded', async () => {
   locationTracker.subscribe(({ position }) => timeline.setUserLatlon(position));
   attachEventFilters(timeline, schedule, locationTracker);
 
+  const refreshScheduleButton = document.getElementById('refreshSchedule');
+  refreshScheduleButton.addEventListener('click', async () => {
+    refreshScheduleButton.disabled = true;
+    updateScheduleRefreshStatus(scheduleResult.metadata, { message: 'Refreshing schedule data…' });
+    const refreshed = await loadScheduleData({ forceRefresh: true });
+
+    if (!refreshed || refreshed.fromCache) {
+      refreshScheduleButton.disabled = false;
+      updateScheduleRefreshStatus(scheduleResult.metadata, { fromCache: true, message: 'Could not refresh while offline. Keeping the cached schedule data.' });
+      return;
+    }
+
+    window.location.reload();
+  });
+
   // go to 1 hour ago
   timeline.goToTime(Date.now() - 60 * 60 * 1000);
-
-  //favouritesDatabase.save([412]);
 });

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,93 @@
+const CACHE_VERSION = '2026-07-11-v1';
+const APP_CACHE = `emf-planner-app-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `emf-planner-runtime-${CACHE_VERSION}`;
+const SCHEDULE_CACHE = `emf-planner-schedule-${CACHE_VERSION}`;
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/img/emp.svg',
+];
+const SCHEDULE_URL_PATTERN = /https:\/\/www\.emfcamp\.org\/schedule\/2026\.json(?:$|[?#])/;
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(APP_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(Promise.all([
+    caches.keys().then((cacheNames) => Promise.all(
+      cacheNames
+        .filter((cacheName) => cacheName.startsWith('emf-planner-') && ![APP_CACHE, RUNTIME_CACHE, SCHEDULE_CACHE].includes(cacheName))
+        .map((cacheName) => caches.delete(cacheName)),
+    )),
+    self.clients.claim(),
+  ]));
+});
+
+const cacheResponse = async (cacheName, request, response) => {
+  if (!response || (!response.ok && response.type !== 'opaque')) {
+    return response;
+  }
+
+  const cache = await caches.open(cacheName);
+  await cache.put(request, response.clone());
+  return response;
+};
+
+const networkFirst = async (request, cacheName) => {
+  const cache = await caches.open(cacheName);
+
+  try {
+    const response = await fetch(request);
+    await cacheResponse(cacheName, request, response);
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request, { ignoreSearch: true });
+    if (cached) {
+      return cached;
+    }
+    throw error;
+  }
+};
+
+const cacheFirst = async (request, cacheName) => {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request, { ignoreSearch: true });
+
+  if (cached) {
+    return cached;
+  }
+
+  const response = await fetch(request);
+  await cacheResponse(cacheName, request, response);
+  return response;
+};
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request, APP_CACHE).catch(() => caches.match('/index.html')));
+    return;
+  }
+
+  if (SCHEDULE_URL_PATTERN.test(request.url)) {
+    event.respondWith(networkFirst(request, SCHEDULE_CACHE));
+    return;
+  }
+
+  if (url.origin === self.location.origin || url.hostname === 'ka-f.webawesome.com') {
+    event.respondWith(cacheFirst(request, RUNTIME_CACHE));
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide reliable offline behaviour for the schedule viewer by caching the app shell and schedule JSON so the app can load when the device is offline.
- Give users visibility into when schedule data was last refreshed and allow a manual refresh of schedule data.
- Persist and surface the last time favourites were imported so users know whether their favourites are available locally.
- Add safe cache invalidation via versioned caches to avoid serving stale assets.

### Description
- Add a versioned service worker that precaches the app shell and static assets, applies a network-first strategy for navigations and the schedule JSON, a cache-first strategy for runtime assets (including WebAwesome), and removes old `emf-planner-*` caches on activation (`static/service-worker.js`).
- Persist schedule JSON and fetch metadata in `localStorage` and implement `loadScheduleData` + `fetchJson` helpers that fall back to the cached copy when offline, and support a forced refresh (`src/js/app.js`).
- Register the service worker and wire up a manual "Refresh schedule now" button and a schedule freshness UI (last refreshed timestamp + age) in the About panel (`index.html`, `src/js/app.js`, `src/css/style.css`).
- Record and expose the last favourites import time in the favourites manager and display it in the Favourites tab after imports (`src/js/FavouritesDatabase.js`, `index.html`, `src/js/app.js`, `src/css/style.css`).

### Testing
- Ran `npm run build` which invoked `webpack` and completed successfully with compiled assets emitted (build succeeded).
- Ran `git diff --check` which produced no whitespace or diff-check errors.
- Confirmed the new `service-worker.js` is present and assets were copied into the build output during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a526ddda82c832bab9cb7e04388da0b)